### PR TITLE
Fix the version of jackson-databind to 2.13.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val igluCoreJson4s = (project in file("iglu-core-json4s"))
   .settings(
     libraryDependencies ++= Seq(
       Dependencies.json4s,
+      Dependencies.jacksonDatabind,
       // Testing
       Dependencies.specs2
     )

--- a/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/DecodersSpec.scala
+++ b/iglu-core-circe/src/test/scala/com/snowplowanalytics/iglu/core/circe/DecodersSpec.scala
@@ -159,7 +159,7 @@ class DecodersSpec extends Specification {
         }
       """
 
-    val expected = "DecodingFailure at .$schema: Attempt to decode value on failed cursor"
+    val expected = "DecodingFailure at .$schema: Missing required field"
 
     result.as[SelfDescribingSchema[Json]].leftMap(_.show) must beLeft(expected)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     // Scala third party
     val circe           = "0.14.2"
     val cats            = "2.8.0"
-    val json4s          = "3.6.11"
+    val json4s          = "3.6.12"
     val jacksonDatabind = "2.13.2.1" // Fixing version to address security vulnerability
 
     // Testing

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   object V {
     // Scala third party
     val circe           = "0.14.2"
-    val cats            = "2.6.1"
+    val cats            = "2.8.0"
     val json4s          = "3.6.11"
     val jacksonDatabind = "2.13.2.1" // Fixing version to address security vulnerability
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,17 +15,19 @@ import sbt._
 object Dependencies {
   object V {
     // Scala third party
-    val circe  = "0.14.1"
-    val cats   = "2.6.1"
-    val json4s = "3.6.11"
+    val circe           = "0.14.1"
+    val cats            = "2.6.1"
+    val json4s          = "3.6.11"
+    val jacksonDatabind = "2.13.2.1" // Fixing version to address security vulnerability
 
     // Testing
     val specs2 = "4.12.3"
   }
 
-  val circe  = "io.circe"      %% "circe-core"     % V.circe
-  val cats   = "org.typelevel" %% "cats-core"      % V.cats
-  val json4s = "org.json4s"    %% "json4s-jackson" % V.json4s
+  val circe            = "io.circe"                   %% "circe-core"      % V.circe
+  val cats             = "org.typelevel"              %% "cats-core"       % V.cats
+  val json4s           = "org.json4s"                 %% "json4s-jackson"  % V.json4s
+  val jacksonDatabind  = "com.fasterxml.jackson.core" % "jackson-databind" % V.jacksonDatabind
 
   // Testing
   val specs2       = "org.specs2" %% "specs2-core"    % V.specs2 % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ import sbt._
 object Dependencies {
   object V {
     // Scala third party
-    val circe           = "0.14.1"
+    val circe           = "0.14.2"
     val cats            = "2.6.1"
     val json4s          = "3.6.11"
     val jacksonDatabind = "2.13.2.1" // Fixing version to address security vulnerability

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val jacksonDatabind = "2.13.2.1" // Fixing version to address security vulnerability
 
     // Testing
-    val specs2 = "4.12.3"
+    val specs2 = "4.15.0"
   }
 
   val circe            = "io.circe"                   %% "circe-core"      % V.circe


### PR DESCRIPTION
Before fixing the version:

```
snyk test
```

> ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.9.10.8
    introduced by org.json4s:json4s-jackson_2.13@3.6.11 > com.fasterxml.jackson.core:jackson-databind@2.9.10.8

After fixing the version:

```
snyk test
```

> ✔ Tested 13 dependencies for known issues, no vulnerable paths found.